### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=An Arduino library for WiFi101 connected devices implementing the Phil
 category=Other
 url=https://github.com/andium/hueDino
 architectures=*
+depends=WiFi101, ArduinoJson


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format